### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI-API.yaml
+++ b/.github/workflows/CI-API.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI-API
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/ChrisTorng/python-project/security/code-scanning/1](https://github.com/ChrisTorng/python-project/security/code-scanning/1)

To fix this issue, add a `permissions` key to the workflow at the root level (before `jobs:`) in `.github/workflows/CI-API.yaml`. This will ensure all jobs in the workflow (unless overridden) use these minimal permissions for the GITHUB_TOKEN. As the workflow only checks out code and runs tests/builds, set `contents: read` to follow the principle of least privilege. No modification to the jobs or steps is required; simply insert the following block:

```yaml
permissions:
  contents: read
```

Place this after the workflow `name` and before `on:` (ideally as the second top-level key).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
